### PR TITLE
Add new tiny stack id

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ name = "Dep"
 sha256 = "79b3ab9e67bf51bae787faaa5c78782752d0e39ea7b0d99e485a181b63a49559"
 source = "https://github.com/golang/dep/archive/v0.5.4.tar.gz"
 source_sha256 = "929c8f759838f98323211ba408a831ea80d93b75beda8584b6d950f393a3298a"
-stacks = ["org.cloudfoundry.stacks.cflinuxfs3","io.buildpacks.stacks.bionic","org.cloudfoundry.stacks.tiny"]
+stacks = ["org.cloudfoundry.stacks.cflinuxfs3","io.buildpacks.stacks.bionic","org.cloudfoundry.stacks.tiny", "io.paketo.stacks.tiny"]
 uri = "https://buildpacks.cloudfoundry.org/dependencies/dep/dep-v0.5.4-linux-x64-cflinuxfs3-79b3ab9e.tgz"
 version = "0.5.4"
 
@@ -28,3 +28,6 @@ id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
 id = "org.cloudfoundry.stacks.tiny"
+
+[[stacks]]
+id = "io.paketo.stacks.tiny"


### PR DESCRIPTION
In preparation for renaming the tiny stack to `io.paketo.stacks.tiny`, we first want all Go language family CNB's to support the current tiny stack id as well as the new one. This way we will not break anyone during the transition. This PR adds the new stack id to the buildpack.toml.

Releng tracker story for reference: https://www.pivotaltracker.com/story/show/172902979