### PR TITLE
Remove old tiny stack ID

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ name = "Dep"
 sha256 = "79b3ab9e67bf51bae787faaa5c78782752d0e39ea7b0d99e485a181b63a49559"
 source = "https://github.com/golang/dep/archive/v0.5.4.tar.gz"
 source_sha256 = "929c8f759838f98323211ba408a831ea80d93b75beda8584b6d950f393a3298a"
-stacks = ["org.cloudfoundry.stacks.cflinuxfs3","io.buildpacks.stacks.bionic","org.cloudfoundry.stacks.tiny", "io.paketo.stacks.tiny"]
+stacks = ["org.cloudfoundry.stacks.cflinuxfs3","io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"]
 uri = "https://buildpacks.cloudfoundry.org/dependencies/dep/dep-v0.5.4-linux-x64-cflinuxfs3-79b3ab9e.tgz"
 version = "0.5.4"
 
@@ -25,9 +25,6 @@ id = "org.cloudfoundry.stacks.cflinuxfs3"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-id = "org.cloudfoundry.stacks.tiny"
 
 [[stacks]]
 id = "io.paketo.stacks.tiny"

--- a/dep/dep.go
+++ b/dep/dep.go
@@ -219,7 +219,7 @@ func (c *Contributor) ContributeStartCommand() error {
 			{
 				Type:    "web",
 				Command: appBinaryPath,
-				Direct:  c.context.Stack == "org.cloudfoundry.stacks.tiny" || c.context.Stack == "io.paketo.stacks.tiny",
+				Direct:  c.context.Stack == "io.paketo.stacks.tiny",
 			},
 		},
 	})

--- a/dep/dep_test.go
+++ b/dep/dep_test.go
@@ -299,38 +299,6 @@ go:
 				}))
 			})
 
-			//Remove this when the org.cloudfoundry.stacks.tiny tag is deprecated
-			when("the tiny stack id is org.cloudfoundry.stacks.tiny", func() {
-				it("will use import-path as the start command on tiny stack", func() {
-					factory.AddPlan(generateMetadata(
-						buildpackplan.Metadata{
-							dep.ImportPath: packageName,
-						}),
-					)
-
-					factory.Build.Stack = "org.cloudfoundry.stacks.tiny"
-
-					appBinaryLayer := factory.Build.Layers.Layer(dep.AppBinary)
-					appBinaryLayer.Touch()
-
-					contributor, _, err := dep.NewContributor(factory.Build, mockRunner)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(contributor.ContributeStartCommand()).To(Succeed())
-
-					appBinaryPath := filepath.Join(appBinaryLayer.Root, "bin", filepath.Base(packageName))
-
-					Expect(factory.Build.Layers).To(test.HaveApplicationMetadata(layers.Metadata{
-						Processes: []layers.Process{
-							{
-								Type:    "web",
-								Command: appBinaryPath,
-								Direct:  true,
-							},
-						},
-					}))
-				})
-			})
-
 			when("the tiny stack id is io.paketo.stacks.tiny", func() {
 				it("will use import-path as the start command on tiny stack", func() {
 					factory.AddPlan(generateMetadata(


### PR DESCRIPTION
We've switched over to the new stack ID (`io.paketo.stacks.tiny`) so we can remove this old one.

Related PRs:
https://github.com/paketo-buildpacks/go-compiler/pull/55
https://github.com/paketo-buildpacks/go/pull/69
https://github.com/paketo-buildpacks/go-mod/pull/59