### PR TITLE
Fixes build_test so that layer writing error case is exercised

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -297,7 +297,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("when the layers directory cannot be written to", func() {
 			it.Before(func() {
-				Expect(os.Chmod(layersDir, 0000)).To(Succeed())
+				Expect(os.Chmod(layersDir, 4444)).To(Succeed())
 			})
 
 			it.After(func() {


### PR DESCRIPTION
Previously, layer-writing test was actually exercising layer-getting error.