### PR TITLE
Support Jammy base/full stacks

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,7 +25,7 @@ api = "0.8"
     sha256 = "79b3ab9e67bf51bae787faaa5c78782752d0e39ea7b0d99e485a181b63a49559"
     source = "https://github.com/golang/dep/archive/v0.5.4.tar.gz"
     source_sha256 = "929c8f759838f98323211ba408a831ea80d93b75beda8584b6d950f393a3298a"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3", "io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "io.buildpacks.stacks.jammy.tiny"]
+    stacks = ["org.cloudfoundry.stacks.cflinuxfs3", "io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "io.buildpacks.stacks.jammy", "io.buildpacks.stacks.jammy.tiny"]
     uri = "https://buildpacks.cloudfoundry.org/dependencies/dep/dep-v0.5.4-linux-x64-cflinuxfs3-79b3ab9e.tgz"
     version = "0.5.4"
 
@@ -35,5 +35,8 @@ api = "0.8"
 [[stacks]]
   id = "io.paketo.stacks.tiny"
 
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"
+  
 [[stacks]]
   id = "io.buildpacks.stacks.jammy.tiny"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Since the Go buildpack runs on the Bionic tiny, base, and full stacks, it should ultimately run on all three Jammy stacks. This will enable the dep + dep ensure workflow to run on all Jammy stacks.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
